### PR TITLE
Update deps + path optimization.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
   - "node"
 sudo: false
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # rdf-canonize ChangeLog
 
+### Changed
+- Update node-forge dependency.
+
 ## 1.0.3 - 2019-03-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # rdf-canonize ChangeLog
 
 ### Changed
+- Optimize away length check on paths.
 - Update node-forge dependency.
 
 ## 1.0.3 - 2019-03-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Optimize away length check on paths.
 - Update node-forge dependency.
+- Update semver dependency.
 
 ## 1.0.3 - 2019-03-06
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib/*.js"
   ],
   "dependencies": {
-    "node-forge": "^0.8.1",
+    "node-forge": "^0.9.1",
     "semver": "^5.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "node-forge": "^0.9.1",
-    "semver": "^5.6.0"
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",


### PR DESCRIPTION
Travis tests failing due to rdf-canonize-native not building in Node.js 12+.  Passes locally.