### PR TITLE
Remove install for rdf-canonize-native.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - "6"
-  - "8"
   - "10"
   - "12"
+  - "14"
   - "node"
 sudo: false
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ node_js:
 sudo: false
 install:
   - npm install
-  # install native module
-  - npm install --no-save rdf-canonize-native
   - npm run fetch-test-suite
 script:
   - if [ "x$BUNDLER" = "x" ]; then npm run test; fi


### PR DESCRIPTION
This solves rdf-canonize-native build failures on node 12 and 14 as shown here: https://travis-ci.org/github/digitalbazaar/rdf-canonize/builds/731728025

However, node6 is failing because evidently an es6 spread operator has slipped in where it should not be.  (see failed CI on this PR).

So, someone who knows how this test suite works with node6 can fix that, or we can drop node6 support all together.  Probably in that case we would/should drop 6 and 8.