### PR TITLE
Update `browser` entry to filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "browser": {
     "./index.js": "./lib/index.js",
-    "./lib/MessageDigest": "./lib/MessageDigest-browser.js",
+    "./lib/MessageDigest.js": "./lib/MessageDigest-browser.js",
     "rdf-canonize-native": false
   }
 }


### PR DESCRIPTION
Similar to https://github.com/digitalbazaar/jsonld.js/pull/429, I'm trying to bundle `jsonld` for browsers and run into issues resolving `crypto`. Using the correct file name fixes the issue for me. 

The browser spec is here: https://github.com/defunctzombie/package-browser-field-spec. It explicitly uses file names as the examples and this resolved the bundler issues I had.