### PR TITLE
Fix escaping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
   webcrypto calls and produces invalid results. It is an error that this
   doesn't fail, but sync code is currently only for testing.
 - Fix various testing and benchmark bugs.
+- Escape and unescape all data.
+- Support 8 hex char unicode values.
 
 ### Removed
 - **BREAKING**: Remove URGNA2012 support. [rdf-canon][] no longer supports or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Update tooling.
 - Update for latest [rdf-canon][] changes: test suite location, README, links,
   and identifiers.
-- More closly align test code with the version in [jsonld.js][].
+- More closely align test code with the version in [jsonld.js][].
   - Use combined test/benchmark system.
   - Support running multiple test jobs in parallel.
 - Refactor `MessageDigest-browser.js` to `MessageDigest-webcrypto.js` so it can
@@ -62,7 +62,7 @@
   doesn't fail, but sync code is currently only for testing.
 - Fix various testing and benchmark bugs.
 - Escape and unescape all data.
-- Support 8 hex char unicode values.
+- Support 8 hex char Unicode values.
 
 ### Removed
 - **BREAKING**: Remove URGNA2012 support. [rdf-canon][] no longer supports or
@@ -198,7 +198,7 @@
 ### Changed
 - Improve N-Quads parsing.
   - Unescape literals.
-  - Handle unicode escapes.
+  - Handle Unicode escapes.
 - N-Quad serialization optimization.
   - Varies based on input by roughly ~1-2x.
 - **BREAKING**: Remove `rdf-canonize-native` as a dependency. The native

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   "URDNA2015" support. A global `RDF_CANONIZE_TRACE_URDNA2015` is available to
   developers to trace calls that use "URDNA2015". See the README for important
   compatibility notes and API details.
+- **BREAKING**: Use latest [rdf-canon][] N-Quads canonical form. This can
+  change the canonical output! There is an expanded set of control characters
+  that are escaped as an `ECHAR` or `UCHAR` instead of using a native
+  representation.
 - **BREAKING**: Use `globalThis` to access `crypto` in browsers. Use a polyfill
   if your environment doesn't support `globalThis`.
 - Update tooling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,17 @@
   developers to trace calls that use "URDNA2015". See the README for important
   compatibility notes and API details.
 - **BREAKING**: Use latest [rdf-canon][] N-Quads canonical form. This can
-  change the canonical output! There is an expanded set of control characters
-  that are escaped as an `ECHAR` or `UCHAR` instead of using a native
-  representation.
+  change the canonical output! There is an expanded set of literal string
+  control characters that are escaped as an `ECHAR` or `UCHAR` instead of using
+  a native representation.
+  - Previously: the canonical N-Quads form used here was encoding `\u000A`
+    (`\n`), `\u000D` (`\r`), `\u0022` (`"`), and `\u005C` (`\`) as `ECHARs`:
+    `\n`, `\r`, `\"`, and `\\`, All other characters were represented as native
+    Unicode.
+  - Now: the output also encodes `\u0008` (`\b`), `\u0009` (`\t`), `\u000C`
+    (`\f`) as `ECHARs` `\b`, `\t`, and `\f`, and encodes the "control"
+    characters in the range of `\u0000-\u001F` and `\u007F` as `UCHARs`
+    `\u00xx`. All other characters are represented as native Unicode.
 - **BREAKING**: Use `globalThis` to access `crypto` in browsers. Use a polyfill
   if your environment doesn't support `globalThis`.
 - Update tooling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,14 @@
   - Node.js using the improved browser algorithm can be ~4-9% faster overall.
   - Node.js native `Buffer` conversion can be ~5-12% faster overall.
 - Optimize a N-Quads serialization call.
-- Optimize N-Quads escape/unescape:
+- Optimize N-Quads escape/unescape calling replace:
   - Run regex test before doing a replace call.
   - Performance difference depends on data and how often escape/unescape would
     need to be called. A benchmark test data showed ~3-5% overall improvement.
+- Optimize N-Quads escape replacement:
+  - Use a pre-computed map of replacement values.
+  - Performance difference depends on the number of replacements. The
+    [rdf-canon][] escaping test showed up to 15% improvement.
 
 ### Fixed
 - Disable native lib tests in a browser.

--- a/lib/NQuads.js
+++ b/lib/NQuads.js
@@ -383,7 +383,7 @@ function _compareTriples(t1, t2) {
   );
 }
 
-const _stringLiteralEscapeRegex = /["\\\n\r]/g;
+const _stringLiteralEscapeRegex = /[\u0000-\u001F\u007F"\\]/g;
 /**
  * Escape string to N-Quads literal.
  *
@@ -397,16 +397,25 @@ function _stringLiteralEscape(s) {
   }
   return s.replace(_stringLiteralEscapeRegex, function(match) {
     switch(match) {
+      case '\b': return '\\b';
+      case '\t': return '\\t';
+      case '\n': return '\\n';
+      case '\f': return '\\f';
+      case '\r': return '\\r';
       case '"': return '\\"';
       case '\\': return '\\\\';
-      case '\n': return '\\n';
-      case '\r': return '\\r';
+      case '\u007F': return '\\u007F';
     }
+    return '\\u' + match
+      .codePointAt(0)
+      .toString(16)
+      .toUpperCase()
+      .padStart(4, '0');
   });
 }
 
 const _stringLiteralUnescapeRegex =
-  /(?:\\([tbnrf"'\\]))|(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
+  /(?:\\([btnfr"'\\]))|(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
 /**
  * Unescape N-Quads literal to string.
  *
@@ -421,11 +430,11 @@ function _stringLiteralUnescape(s) {
   return s.replace(_stringLiteralUnescapeRegex, function(match, code, u, U) {
     if(code) {
       switch(code) {
-        case 't': return '\t';
         case 'b': return '\b';
+        case 't': return '\t';
         case 'n': return '\n';
-        case 'r': return '\r';
         case 'f': return '\f';
+        case 'r': return '\r';
         case '"': return '"';
         case '\'': return '\'';
         case '\\': return '\\';

--- a/lib/NQuads.js
+++ b/lib/NQuads.js
@@ -468,7 +468,11 @@ for(let n = 0; n <= 0x7f; ++n) {
 }
 
 /**
- * Escape IRI to N-Quads IRI
+ * Escape IRI to N-Quads IRI.
+ *
+ * @param {string} s - IRI to escape.
+ *
+ * @returns {string} - Escaped N-Quads IRI.
  */
 function _iriEscape(s) {
   if(!_iriEscapeRegex.test(s)) {
@@ -483,7 +487,11 @@ const _iriUnescapeRegex =
   /(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
 
 /**
- * Unescape N-Quads IRI to IRI
+ * Unescape N-Quads IRI to IRI.
+ *
+ * @param {string} s - IRI to unescape.
+ *
+ * @returns {string} - Unescaped N-Quads IRI.
  */
 function _iriUnescape(s) {
   if(!_iriUnescapeRegex.test(s)) {

--- a/lib/NQuads.js
+++ b/lib/NQuads.js
@@ -384,6 +384,25 @@ function _compareTriples(t1, t2) {
 }
 
 const _stringLiteralEscapeRegex = /[\u0000-\u001F\u007F"\\]/g;
+const _stringLiteralEscapeMap = [];
+for(let n = 0; n <= 0x7f; ++n) {
+  if(_stringLiteralEscapeRegex.test(String.fromCharCode(n))) {
+    // default UCHAR mapping
+    _stringLiteralEscapeMap[n] =
+      '\\u' + n.toString(16).toUpperCase().padStart(4, '0');
+    // reset regex
+    _stringLiteralEscapeRegex.lastIndex = 0;
+  }
+}
+// special ECHAR mappings
+_stringLiteralEscapeMap['\b'.codePointAt(0)] = '\\b';
+_stringLiteralEscapeMap['\t'.codePointAt(0)] = '\\t';
+_stringLiteralEscapeMap['\n'.codePointAt(0)] = '\\n';
+_stringLiteralEscapeMap['\f'.codePointAt(0)] = '\\f';
+_stringLiteralEscapeMap['\r'.codePointAt(0)] = '\\r';
+_stringLiteralEscapeMap['"' .codePointAt(0)] = '\\"';
+_stringLiteralEscapeMap['\\'.codePointAt(0)] = '\\\\';
+
 /**
  * Escape string to N-Quads literal.
  *
@@ -396,26 +415,13 @@ function _stringLiteralEscape(s) {
     return s;
   }
   return s.replace(_stringLiteralEscapeRegex, function(match) {
-    switch(match) {
-      case '\b': return '\\b';
-      case '\t': return '\\t';
-      case '\n': return '\\n';
-      case '\f': return '\\f';
-      case '\r': return '\\r';
-      case '"': return '\\"';
-      case '\\': return '\\\\';
-      case '\u007F': return '\\u007F';
-    }
-    return '\\u' + match
-      .codePointAt(0)
-      .toString(16)
-      .toUpperCase()
-      .padStart(4, '0');
+    return _stringLiteralEscapeMap[match.codePointAt(0)];
   });
 }
 
 const _stringLiteralUnescapeRegex =
   /(?:\\([btnfr"'\\]))|(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
+
 /**
  * Unescape N-Quads literal to string.
  *
@@ -450,6 +456,17 @@ function _stringLiteralUnescape(s) {
 }
 
 const _iriEscapeRegex = /[\u0000-\u0020<>"{}|^`\\]/g;
+const _iriEscapeRegexMap = [];
+for(let n = 0; n <= 0x7f; ++n) {
+  if(_iriEscapeRegex.test(String.fromCharCode(n))) {
+    // UCHAR mapping
+    _iriEscapeRegexMap[n] =
+      '\\u' + n.toString(16).toUpperCase().padStart(4, '0');
+    // reset regex
+    _iriEscapeRegex.lastIndex = 0;
+  }
+}
+
 /**
  * Escape IRI to N-Quads IRI
  */
@@ -458,12 +475,13 @@ function _iriEscape(s) {
     return s;
   }
   return s.replace(_iriEscapeRegex, function(match) {
-    return '\\u' + match.codePointAt(0).toString(16).padStart(4, '0');
+    return _iriEscapeRegexMap[match.codePointAt(0)];
   });
 }
 
 const _iriUnescapeRegex =
   /(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
+
 /**
  * Unescape N-Quads IRI to IRI
  */

--- a/lib/NQuads.js
+++ b/lib/NQuads.js
@@ -17,7 +17,7 @@ const TYPE_DEFAULT_GRAPH = 'DefaultGraph';
 // build regexes
 const REGEX = {};
 (() => {
-  const iri = '(?:<([^:]+:[^>]*)>)';
+  // https://www.w3.org/TR/n-quads/#sec-grammar
   // https://www.w3.org/TR/turtle/#grammar-production-BLANK_NODE_LABEL
   const PN_CHARS_BASE =
     'A-Z' + 'a-z' +
@@ -49,19 +49,27 @@ const REGEX = {};
       '(?:[' + PN_CHARS_U + '0-9])' +
       '(?:(?:[' + PN_CHARS + '.])*(?:[' + PN_CHARS + ']))?' +
     ')';
+  // Older simple regex: const IRI = '(?:<([^:]+:[^>]*)>)';
+  const UCHAR4 = '\\\\u[0-9A-Fa-f]{4}';
+  const UCHAR8 = '\\\\U[0-9A-Fa-f]{8}';
+  const IRI = '(?:<((?:' +
+    '[^\u0000-\u0020<>"{}|^`\\\\]' + '|' +
+    UCHAR4 + '|' +
+    UCHAR8 +
+    ')*)>)';
   const bnode = BLANK_NODE_LABEL;
   const plain = '"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"';
-  const datatype = '(?:\\^\\^' + iri + ')';
+  const datatype = '(?:\\^\\^' + IRI + ')';
   const language = '(?:@([a-zA-Z]+(?:-[a-zA-Z0-9]+)*))';
   const literal = '(?:' + plain + '(?:' + datatype + '|' + language + ')?)';
   const ws = '[ \\t]+';
   const wso = '[ \\t]*';
 
   // define quad part regexes
-  const subject = '(?:' + iri + '|' + bnode + ')' + ws;
-  const property = iri + ws;
-  const object = '(?:' + iri + '|' + bnode + '|' + literal + ')' + wso;
-  const graphName = '(?:\\.|(?:(?:' + iri + '|' + bnode + ')' + wso + '\\.))';
+  const subject = '(?:' + IRI + '|' + bnode + ')' + ws;
+  const property = IRI + ws;
+  const object = '(?:' + IRI + '|' + bnode + '|' + literal + ')' + wso;
+  const graphName = '(?:\\.|(?:(?:' + IRI + '|' + bnode + ')' + wso + '\\.))';
 
   // end of line and empty regexes
   REGEX.eoln = /(?:\r\n)|(?:\n)|(?:\r)/g;
@@ -109,19 +117,33 @@ module.exports = class NQuads {
 
       // get subject
       if(match[1] !== undefined) {
-        quad.subject = {termType: TYPE_NAMED_NODE, value: match[1]};
+        quad.subject = {
+          termType: TYPE_NAMED_NODE,
+          value: _iriUnescape(match[1])
+        };
       } else {
-        quad.subject = {termType: TYPE_BLANK_NODE, value: match[2]};
+        quad.subject = {
+          termType: TYPE_BLANK_NODE, value: match[2]
+        };
       }
 
       // get predicate
-      quad.predicate = {termType: TYPE_NAMED_NODE, value: match[3]};
+      quad.predicate = {
+        termType: TYPE_NAMED_NODE,
+        value: _iriUnescape(match[3])
+      };
 
       // get object
       if(match[4] !== undefined) {
-        quad.object = {termType: TYPE_NAMED_NODE, value: match[4]};
+        quad.object = {
+          termType: TYPE_NAMED_NODE,
+          value: _iriUnescape(match[4])
+        };
       } else if(match[5] !== undefined) {
-        quad.object = {termType: TYPE_BLANK_NODE, value: match[5]};
+        quad.object = {
+          termType: TYPE_BLANK_NODE,
+          value: match[5]
+        };
       } else {
         quad.object = {
           termType: TYPE_LITERAL,
@@ -131,21 +153,21 @@ module.exports = class NQuads {
           }
         };
         if(match[7] !== undefined) {
-          quad.object.datatype.value = match[7];
+          quad.object.datatype.value = _iriUnescape(match[7]);
         } else if(match[8] !== undefined) {
           quad.object.datatype.value = RDF_LANGSTRING;
           quad.object.language = match[8];
         } else {
           quad.object.datatype.value = XSD_STRING;
         }
-        quad.object.value = _unescape(match[6]);
+        quad.object.value = _stringLiteralUnescape(match[6]);
       }
 
       // get graph
       if(match[9] !== undefined) {
         quad.graph = {
           termType: TYPE_NAMED_NODE,
-          value: match[9]
+          value: _iriUnescape(match[9])
         };
       } else if(match[10] !== undefined) {
         quad.graph = {
@@ -216,34 +238,34 @@ module.exports = class NQuads {
 
     // subject can only be NamedNode or BlankNode
     if(s.termType === TYPE_NAMED_NODE) {
-      nquad += `<${s.value}>`;
+      nquad += `<${_iriEscape(s.value)}>`;
     } else {
       nquad += `${s.value}`;
     }
 
     // predicate can only be NamedNode
-    nquad += ` <${p.value}> `;
+    nquad += ` <${_iriEscape(p.value)}> `;
 
     // object is NamedNode, BlankNode, or Literal
     if(o.termType === TYPE_NAMED_NODE) {
-      nquad += `<${o.value}>`;
+      nquad += `<${_iriEscape(o.value)}>`;
     } else if(o.termType === TYPE_BLANK_NODE) {
       nquad += o.value;
     } else {
-      nquad += `"${_escape(o.value)}"`;
+      nquad += `"${_stringLiteralEscape(o.value)}"`;
       if(o.datatype.value === RDF_LANGSTRING) {
         if(o.language) {
           nquad += `@${o.language}`;
         }
       } else if(o.datatype.value !== XSD_STRING) {
-        nquad += `^^<${o.datatype.value}>`;
+        nquad += `^^<${_iriEscape(o.datatype.value)}>`;
       }
     }
 
     // graph can only be NamedNode or BlankNode (or DefaultGraph, but that
     // does not add to `nquad`)
     if(g.termType === TYPE_NAMED_NODE) {
-      nquad += ` <${g.value}>`;
+      nquad += ` <${_iriEscape(g.value)}>`;
     } else if(g.termType === TYPE_BLANK_NODE) {
       nquad += ` ${g.value}`;
     }
@@ -281,6 +303,7 @@ module.exports = class NQuads {
       literal: TYPE_LITERAL
     };
 
+    // FIXME escape
     for(const graphName in dataset) {
       const triples = dataset[graphName];
       triples.forEach(triple => {
@@ -360,7 +383,7 @@ function _compareTriples(t1, t2) {
   );
 }
 
-const _escapeRegex = /["\\\n\r]/g;
+const _stringLiteralEscapeRegex = /["\\\n\r]/g;
 /**
  * Escape string to N-Quads literal.
  *
@@ -368,11 +391,11 @@ const _escapeRegex = /["\\\n\r]/g;
  *
  * @returns {string} - Escaped N-Quads literal.
  */
-function _escape(s) {
-  if(!_escapeRegex.test(s)) {
+function _stringLiteralEscape(s) {
+  if(!_stringLiteralEscapeRegex.test(s)) {
     return s;
   }
-  return s.replace(_escapeRegex, function(match) {
+  return s.replace(_stringLiteralEscapeRegex, function(match) {
     switch(match) {
       case '"': return '\\"';
       case '\\': return '\\\\';
@@ -382,7 +405,7 @@ function _escape(s) {
   });
 }
 
-const _unescapeRegex =
+const _stringLiteralUnescapeRegex =
   /(?:\\([tbnrf"'\\]))|(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
 /**
  * Unescape N-Quads literal to string.
@@ -391,11 +414,11 @@ const _unescapeRegex =
  *
  * @returns {string} - Unescaped N-Quads literal.
  */
-function _unescape(s) {
-  if(!_unescapeRegex.test(s)) {
+function _stringLiteralUnescape(s) {
+  if(!_stringLiteralUnescapeRegex.test(s)) {
     return s;
   }
-  return s.replace(_unescapeRegex, function(match, code, u, U) {
+  return s.replace(_stringLiteralUnescapeRegex, function(match, code, u, U) {
     if(code) {
       switch(code) {
         case 't': return '\t';
@@ -412,8 +435,39 @@ function _unescape(s) {
       return String.fromCharCode(parseInt(u, 16));
     }
     if(U) {
-      // FIXME: support larger values
-      throw new Error('Unsupported U escape');
+      return String.fromCodePoint(parseInt(U, 16));
+    }
+  });
+}
+
+const _iriEscapeRegex = /[\u0000-\u0020<>"{}|^`\\]/g;
+/**
+ * Escape IRI to N-Quads IRI
+ */
+function _iriEscape(s) {
+  if(!_iriEscapeRegex.test(s)) {
+    return s;
+  }
+  return s.replace(_iriEscapeRegex, function(match) {
+    return '\\u' + match.codePointAt(0).toString(16).padStart(4, '0');
+  });
+}
+
+const _iriUnescapeRegex =
+  /(?:\\u([0-9A-Fa-f]{4}))|(?:\\U([0-9A-Fa-f]{8}))/g;
+/**
+ * Unescape N-Quads IRI to IRI
+ */
+function _iriUnescape(s) {
+  if(!_iriUnescapeRegex.test(s)) {
+    return s;
+  }
+  return s.replace(_iriUnescapeRegex, function(match, u, U) {
+    if(u) {
+      return String.fromCharCode(parseInt(u, 16));
+    }
+    if(U) {
+      return String.fromCodePoint(parseInt(U, 16));
     }
   });
 }


### PR DESCRIPTION
- Fix escaping and unescaping.
- Support 8 hex char unicode.

**NOTE**: Escaping causes a serious performance regression with the initial version here.  An optimization and benchmarks are forthcoming in another PR.  This checkpoint is here for comparison and testing.

Tests available: https://github.com/w3c/rdf-canon/pull/81