### PR TITLE
Drop Node.js 12.x/14.x support, update tooling.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,14 @@
 module.exports = {
+  root: true,
   env: {
     browser: true,
     commonjs: true,
     node: true
   },
-  extends: 'eslint-config-digitalbazaar',
-  root: true
+  extends: [
+    'digitalbazaar'
+  ],
+  ignorePatterns: [
+    'test-suites'
+  ]
 };

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,12 +3,27 @@ name: Node.js CI
 on: [push]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - name: Run eslint
+      run: npm run lint
   test-node:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
@@ -21,44 +36,34 @@ jobs:
       run: npm run fetch-test-suite
     - name: Run test with Node.js ${{ matrix.node-version }}
       run: npm run test-node
-#  test-karma:
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 10
-#    strategy:
-#      matrix:
-#        node-version: [14.x]
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Use Node.js ${{ matrix.node-version }}
-#      uses: actions/setup-node@v1
-#      with:
-#        node-version: ${{ matrix.node-version }}
-#    - run: npm install
-#    - name: Run karma tests
-#      run: npm run test-karma
-  lint:
+  test-karma:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
+        bundler: [webpack, browserify]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - name: Run eslint
-      run: npm run lint
+    - name: Install
+      run: npm install
+    - name: Fetch test suite
+      run: npm run fetch-test-suite
+    - name: Run karma tests
+      run: npm run test-karma
+      env:
+        BUNDLER: ${{ matrix.bundler }}
   coverage:
-#    needs: [test-node, test-karma]
-    needs: [test-node]
+    needs: [test-node, test-karma]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,32 @@
 ## 4.0.0 - 2023-03-xx
 
 ### Changed
-- Update for latest [rdf-canon][] changes: test suite location, README,
-  links, and identifiers.
+- Update for latest [rdf-canon][] changes: test suite location, README, links,
+  and identifiers.
 - More closly align test code with the version in [jsonld.js][].
   - Use combined test/benchmark system.
   - Update with special x10 benchmarks.
+- Update tooling.
 
 ### Removed
 - **BREAKING**: Remove URGNA2012 support. [rdf-canon][] no longer supports or
   has a test suite for URGNA2012. URDNA2015 has been the preferred algorithm
   for many years.
+- **BREAKING**: Remove support for Node.js 12.x and 14.x. This is done to allow
+  updates to tooling that no longer support older Node.js versions. The library
+  code has not yet changed to be incompatibile with older Node.js versions but
+  it will no longer be tested and may become incompatibile at any time.
 - Remove `benchmark/benchmark.js` tool in favor of combined test system and
   benchmarking control via environment vars.
+
+### Fixed
+- Disable native lib use when testing in a browser.
+- Disable sync tests in a browser. The sync code attempts to use the async
+  webcrypto calls and produces invalid results. It is an error that this
+  doesn't fail, but sync code is currently only for testing.
+
+### Added
+- Test with karma.
 
 ## 3.3.0 - 2022-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 4.0.0 - 2023-03-xx
 
+### Added
+- Test with karma.
+
 ### Changed
 - Update for latest [rdf-canon][] changes: test suite location, README, links,
   and identifiers.
@@ -9,6 +12,12 @@
   - Use combined test/benchmark system.
   - Update with special x10 benchmarks.
 - Update tooling.
+
+### Fixed
+- Disable native lib use when testing in a browser.
+- Disable sync tests in a browser. The sync code attempts to use the async
+  webcrypto calls and produces invalid results. It is an error that this
+  doesn't fail, but sync code is currently only for testing.
 
 ### Removed
 - **BREAKING**: Remove URGNA2012 support. [rdf-canon][] no longer supports or
@@ -20,15 +29,6 @@
   it will no longer be tested and may become incompatibile at any time.
 - Remove `benchmark/benchmark.js` tool in favor of combined test system and
   benchmarking control via environment vars.
-
-### Fixed
-- Disable native lib use when testing in a browser.
-- Disable sync tests in a browser. The sync code attempts to use the async
-  webcrypto calls and produces invalid results. It is an error that this
-  doesn't fail, but sync code is currently only for testing.
-
-### Added
-- Test with karma.
 
 ## 3.3.0 - 2022-09-17
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,164 @@
+/**
+ * Karam configuration for rdf-canonize.
+ *
+ * See ./test/test.js for env options.
+ *
+ * @author Dave Longley
+ * @author David I. Lehn
+ *
+ * Copyright (c) 2011-2023 Digital Bazaar, Inc. All rights reserved.
+ */
+const os = require('os');
+const webpack = require('webpack');
+
+module.exports = function(config) {
+  // bundler to test: webpack, browserify
+  const bundler = process.env.BUNDLER || 'webpack';
+
+  const frameworks = ['mocha', 'server-side'];
+  // main bundle preprocessors
+  const preprocessors = ['babel'];
+
+  if(bundler === 'browserify') {
+    frameworks.push(bundler);
+    preprocessors.push(bundler);
+  } else if(bundler === 'webpack') {
+    preprocessors.push(bundler);
+    preprocessors.push('sourcemap');
+  } else {
+    throw Error('Unknown bundler');
+  }
+
+  config.set({
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks,
+
+    // list of files / patterns to load in the browser
+    files: [
+      {
+        pattern: 'test/test-karma.js',
+        watched: false, served: true, included: true
+      }
+    ],
+
+    // list of files to exclude
+    exclude: [],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors:
+    // https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      //'tests/*.js': ['webpack', 'babel'] //preprocessors
+      'test/*.js': preprocessors
+    },
+
+    webpack: {
+      mode: 'development',
+      devtool: 'inline-source-map',
+      plugins: [
+        new webpack.DefinePlugin({
+          'process.env.BAIL': JSON.stringify(process.env.BAIL),
+          'process.env.BENCHMARK': JSON.stringify(process.env.BENCHMARK),
+          'process.env.EARL': JSON.stringify(process.env.EARL),
+          'process.env.TESTS': JSON.stringify(process.env.TESTS),
+          'process.env.TEST_ENV': JSON.stringify(process.env.TEST_ENV),
+          'process.env.TEST_ROOT_DIR': JSON.stringify(__dirname),
+          'process.env.VERBOSE_SKIP': JSON.stringify(process.env.VERBOSE_SKIP),
+          // for 'auto' test env
+          'process.env._TEST_ENV_ARCH': JSON.stringify(process.arch),
+          'process.env._TEST_ENV_CPU': JSON.stringify(os.cpus()[0].model),
+          'process.env._TEST_ENV_CPU_COUNT': JSON.stringify(os.cpus().length),
+          'process.env._TEST_ENV_PLATFORM': JSON.stringify(process.platform),
+          'process.env._TEST_VERSION':
+            JSON.stringify(require('./package.json').version)
+        })
+      ],
+      module: {
+        noParse: [
+          // avoid munging internal benchmark script magic
+          /benchmark/
+        ]
+      }
+    },
+
+    browserify: {
+      debug: false,
+      transform: [
+        [
+          'envify', {
+            BAIL: process.env.BAIL,
+            BENCHMARK: process.env.BENCHMARK,
+            EARL: process.env.EARL,
+            TESTS: process.env.TESTS,
+            TEST_ENV: process.env.TEST_ENV,
+            TEST_ROOT_DIR: __dirname,
+            VERBOSE_SKIP: process.env.VERBOSE_SKIP,
+            // for 'auto' test env
+            _TEST_ENV_ARCH: process.arch,
+            _TEST_ENV_CPU: os.cpus()[0].model,
+            _TEST_ENV_CPU_COUNT: os.cpus().length,
+            _TEST_ENV_PLATFORM: process.platform,
+            _TEST_VERSION: require('./package.json').version
+          }
+        ]
+      ],
+      plugin: [
+        [
+          require('esmify')
+        ]
+      ]
+    },
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    //reporters: ['progress'],
+    reporters: ['mocha'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR ||
+    // config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // enable / disable watching file and executing tests whenever any file
+    // changes
+    autoWatch: false,
+
+    // start these browsers
+    // available browser launchers:
+    // https://npmjs.org/browse/keyword/karma-launcher
+    //browsers: ['ChromeHeadless', 'Chrome', 'Firefox', 'Safari'],
+    browsers: ['ChromeHeadless'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity,
+
+    // Mocha
+    client: {
+      mocha: {
+        // increase from default 2s
+        timeout: 10000,
+        reporter: 'html',
+        delay: true
+      }
+    },
+
+    // Proxied paths
+    proxies: {}
+  });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 /**
- * Karam configuration for rdf-canonize.
+ * Karma configuration for rdf-canonize.
  *
  * See ./test/test.js for env options.
  *

--- a/package.json
+++ b/package.json
@@ -30,38 +30,54 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "chai": "^4.2.0",
+    "browserify": "^17.0.0",
+    "chai": "^4.3.7",
     "delay": "^5.0.0",
-    "eslint": "^7.23.0",
-    "eslint-config-digitalbazaar": "^2.6.1",
-    "fs-extra": "^10.1.0",
+    "envify": "^4.1.0",
+    "eslint": "^8.36.0",
+    "eslint-config-digitalbazaar": "^4.2.0",
+    "esmify": "^2.1.1",
+    "fs-extra": "^11.1.0",
     "join-path-js": "^0.0.0",
-    "klona": "^2.0.5",
-    "mocha": "^8.3.2",
+    "karma": "^6.4.1",
+    "karma-babel-preprocessor": "^8.0.2",
+    "karma-browserify": "^8.1.0",
+    "karma-chrome-launcher": "^3.1.1",
+    "karma-mocha": "^2.0.1",
+    "karma-mocha-reporter": "^2.2.5",
+    "karma-server-side": "github:fargies/karma-server-side#9397553473fcbc2aaabb7dc9f59e96f9ff26791c",
+    "karma-sourcemap-loader": "^0.4.0",
+    "karma-webpack": "^5.0.0",
+    "klona": "^2.0.6",
+    "mocha": "^10.2.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "nsolid": "0.0.0",
-    "nyc": "^15.1.0"
+    "nsolid": "1.0.0",
+    "nyc": "^15.1.0",
+    "webpack": "^5.76.2"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=16"
   },
   "keywords": [
     "JSON",
-    "Linked Data",
     "JSON-LD",
+    "Linked Data",
     "RDF",
+    "RDF Dataset Canonicalization",
     "Semantic Web",
-    "jsonld"
+    "jsonld",
+    "rdf-canon"
   ],
   "scripts": {
     "fetch-test-suite": "if [ ! -e test-suites/rdf-canon ]; then git clone --depth 1 https://github.com/w3c/rdf-canon.git test-suites/rdf-canon; fi",
     "test": "npm run test-node",
     "test-node": "NODE_ENV=test mocha --delay -A -R spec --check-leaks test/test-node.js",
+    "test-karma": "NODE_ENV=test karma start",
     "benchmark": "node benchmark/benchmark.js",
     "coverage": "NODE_ENV=test nyc npm test",
     "coverage-ci": "NODE_ENV=test nyc --reporter=lcovonly --reporter=text-summary --reporter=text npm run test",
     "coverage-report": "nyc report",
-    "lint": "eslint '*.js' 'lib/*.js' 'test/*.js' 'benchmark/*.js'"
+    "lint": "eslint ."
   },
   "browser": {
     "./lib/MessageDigest.js": "./lib/MessageDigest-browser.js",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint": "^8.36.0",
     "eslint-config-digitalbazaar": "^4.2.0",
     "esmify": "^2.1.1",
-    "fs-extra": "^11.1.0",
+    "fs-extra": "^11.1.1",
     "join-path-js": "^0.0.0",
     "karma": "^6.4.1",
     "karma-babel-preprocessor": "^8.0.2",
@@ -53,7 +53,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "nsolid": "1.0.0",
     "nyc": "^15.1.0",
-    "webpack": "^5.76.2"
+    "webpack": "^5.76.3"
   },
   "engines": {
     "node": ">=16"

--- a/test/EarlReport.js
+++ b/test/EarlReport.js
@@ -47,6 +47,7 @@ const _benchmarkContext = {
   // per BenchmarkResult
   'jldb:environment': {'@type': '@id'},
   'jldb:hz': {'@type': 'xsd:float'},
+  'jldb:jobs': {'@type': 'xsd:integer'},
   'jldb:rme': {'@type': 'xsd:float'}
 };
 /* eslint-enable quote-props */

--- a/test/test-karma.js
+++ b/test/test-karma.js
@@ -18,13 +18,6 @@ const common = require('./test.js');
 const server = require('karma-server-side');
 const join = require('join-path-js');
 
-// special benchmark setup
-const _ = require('lodash');
-//const _process = require('process');
-//const Benchmark = benchmark.runInContext({_, _process});
-const Benchmark = benchmark.runInContext({_});
-window.Benchmark = Benchmark;
-
 const entries = [];
 
 if(process.env.TESTS) {

--- a/test/test-karma.js
+++ b/test/test-karma.js
@@ -52,79 +52,28 @@ if(process.env.TESTS) {
   //entries.push(join(_top, 'tests/misc.js'));
 }
 
-// test environment
-let testEnv = null;
-if(process.env.TEST_ENV) {
-  let _test_env = process.env.TEST_ENV;
-  if(!(['0', 'false'].includes(_test_env))) {
-    testEnv = {};
-    if(['1', 'true', 'auto'].includes(_test_env)) {
-      _test_env = 'auto';
-    }
-    _test_env.split(',').forEach(pair => {
-      if(pair === 'auto') {
-        testEnv.name = 'auto';
-        testEnv.arch = 'auto';
-        testEnv.cpu = 'auto';
-        testEnv.cpuCount = 'auto';
-        testEnv.platform = 'auto';
-        testEnv.runtime = 'auto';
-        testEnv.runtimeVersion = 'auto';
-        testEnv.comment = 'auto';
-        testEnv.version = 'auto';
-      } else {
-        const kv = pair.split('=');
-        if(kv.length === 1) {
-          testEnv[kv[0]] = 'auto';
-        } else {
-          testEnv[kv[0]] = kv.slice(1).join('=');
-        }
-      }
-    });
-    if(testEnv.label === 'auto') {
-      testEnv.label = '';
-    }
-    if(testEnv.arch === 'auto') {
-      testEnv.arch = process.env._TEST_ENV_ARCH;
-    }
-    if(testEnv.cpu === 'auto') {
-      testEnv.cpu = process.env._TEST_ENV_CPU;
-    }
-    if(testEnv.cpuCount === 'auto') {
-      testEnv.cpuCount = process.env._TEST_ENV_CPU_COUNT;
-    }
-    if(testEnv.platform === 'auto') {
-      testEnv.platform = process.env._TEST_ENV_PLATFORM;
-    }
-    if(testEnv.runtime === 'auto') {
-      testEnv.runtime = 'browser';
-    }
-    if(testEnv.runtimeVersion === 'auto') {
-      testEnv.runtimeVersion = '(unknown)';
-    }
-    if(testEnv.comment === 'auto') {
-      testEnv.comment = '';
-    }
-    if(testEnv.version === 'auto') {
-      testEnv.version = require('../package.json').version;
-    }
-  }
-}
+// test environment defaults
+const testEnvDefaults = {
+  label: '',
+  arch: process.env._TEST_ENV_ARCH,
+  cpu: process.env._TEST_ENV_CPU,
+  cpuCount: process.env._TEST_ENV_CPU_COUNT,
+  platform: process.env._TEST_ENV_PLATFORM,
+  runtime: 'browser',
+  runtimeVersion: '(unknown)',
+  comment: '',
+  version: require('../package.json').version
+};
 
-let benchmarkOptions = null;
-if(process.env.BENCHMARK) {
-  if(!(['0', 'false'].includes(process.env.BENCHMARK))) {
-    benchmarkOptions = {};
-    if(!(['1', 'true'].includes(process.env.BENCHMARK))) {
-      process.env.BENCHMARK.split(',').forEach(pair => {
-        const kv = pair.split('=');
-        benchmarkOptions[kv[0]] = kv[1];
-      });
-    }
-  }
-}
+const env = {
+  BAIL: process.env.BAIL,
+  BENCHMARK: process.env.BENCHMARK,
+  TEST_ENV: process.env.TEST_ENV,
+  VERBOSE_SKIP: process.env.VERBOSE_SKIP
+};
 
 const options = {
+  env,
   nodejs: false,
   assert,
   benchmark,
@@ -137,11 +86,8 @@ const options = {
   earl: {
     filename: process.env.EARL
   },
-  verboseSkip: process.env.VERBOSE_SKIP === 'true',
-  bailOnError: process.env.BAIL === 'true',
   entries,
-  testEnv,
-  benchmarkOptions,
+  testEnvDefaults,
   readFile: filename => {
     return server.run(filename, function(filename) {
       const fs = serverRequire('fs-extra');

--- a/test/test-node.js
+++ b/test/test-node.js
@@ -54,79 +54,28 @@ if(process.env.TESTS) {
   //entries.push(path.resolve(_top, 'test/misc.js'));
 }
 
-// test environment
-let testEnv = null;
-if(process.env.TEST_ENV) {
-  let _test_env = process.env.TEST_ENV;
-  if(!(['0', 'false'].includes(_test_env))) {
-    testEnv = {};
-    if(['1', 'true', 'auto'].includes(_test_env)) {
-      _test_env = 'auto';
-    }
-    _test_env.split(',').forEach(pair => {
-      if(pair === 'auto') {
-        testEnv.name = 'auto';
-        testEnv.arch = 'auto';
-        testEnv.cpu = 'auto';
-        testEnv.cpuCount = 'auto';
-        testEnv.platform = 'auto';
-        testEnv.runtime = 'auto';
-        testEnv.runtimeVersion = 'auto';
-        testEnv.comment = 'auto';
-        testEnv.version = 'auto';
-      } else {
-        const kv = pair.split('=');
-        if(kv.length === 1) {
-          testEnv[kv[0]] = 'auto';
-        } else {
-          testEnv[kv[0]] = kv.slice(1).join('=');
-        }
-      }
-    });
-    if(testEnv.label === 'auto') {
-      testEnv.label = '';
-    }
-    if(testEnv.arch === 'auto') {
-      testEnv.arch = process.arch;
-    }
-    if(testEnv.cpu === 'auto') {
-      testEnv.cpu = os.cpus()[0].model;
-    }
-    if(testEnv.cpuCount === 'auto') {
-      testEnv.cpuCount = os.cpus().length;
-    }
-    if(testEnv.platform === 'auto') {
-      testEnv.platform = process.platform;
-    }
-    if(testEnv.runtime === 'auto') {
-      testEnv.runtime = 'Node.js';
-    }
-    if(testEnv.runtimeVersion === 'auto') {
-      testEnv.runtimeVersion = process.version;
-    }
-    if(testEnv.comment === 'auto') {
-      testEnv.comment = '';
-    }
-    if(testEnv.version === 'auto') {
-      testEnv.version = require('../package.json').version;
-    }
-  }
-}
+// test environment defaults
+const testEnvDefaults = {
+  label: '',
+  arch: process.arch,
+  cpu: os.cpus()[0].model,
+  cpuCount: os.cpus().length,
+  platform: process.platform,
+  runtime: 'Node.js',
+  runtimeVersion: process.version,
+  comment: '',
+  version: require('../package.json').version
+};
 
-let benchmarkOptions = null;
-if(process.env.BENCHMARK) {
-  if(!(['0', 'false'].includes(process.env.BENCHMARK))) {
-    benchmarkOptions = {};
-    if(!(['1', 'true'].includes(process.env.BENCHMARK))) {
-      process.env.BENCHMARK.split(',').forEach(pair => {
-        const kv = pair.split('=');
-        benchmarkOptions[kv[0]] = kv[1];
-      });
-    }
-  }
-}
+const env = {
+  BAIL: process.env.BAIL,
+  BENCHMARK: process.env.BENCHMARK,
+  TEST_ENV: process.env.TEST_ENV,
+  VERBOSE_SKIP: process.env.VERBOSE_SKIP
+};
 
 const options = {
+  env,
   nodejs: {
     path
   },
@@ -137,11 +86,8 @@ const options = {
   earl: {
     filename: process.env.EARL
   },
-  verboseSkip: process.env.VERBOSE_SKIP === 'true',
-  bailOnError: process.env.BAIL === 'true',
   entries,
-  testEnv,
-  benchmarkOptions,
+  testEnvDefaults,
   readFile: filename => {
     return fs.readFile(filename, 'utf8');
   },


### PR DESCRIPTION
- **BREAKING**: Remove support for Node.js 12.x and 14.x. This is done to allow updates to tooling that no longer support older Node.js versions.
- Update development dependencies.
- Add karma testing.
  - Use karma-server-side PR fork hash to support modern karma.
- Update keywords.
- Move test/benchmark env docs into common test.js.
- Disable native lib use when testing in a browser.
- Disable sync tests in a browser. The sync code attempts to use the async webcrypto calls and produces invalid results. It is an error that this doesn't fail, but sync code is currently only for testing.
- Only load rdf-canon tests once.