### PR TITLE
Optimize WebCrypto bytes-to-hex.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Refactor `MessageDigest-browser.js` to `MessageDigest-webcrypto.js` so it can
   also be optionally used with Node.js.
 - Move platform specific support into `platform.js` and `platform-browser.js`.
+- Optimize WebCrypto bytes to hex conversion:
+  - Improvement depends on number of digests performed.
+  - Node.js using the improved browser algorithm can be ~4-9% faster overall.
+  - Node.js native `Buffer` conversion can be ~5-12% faster overall.
 
 ### Fixed
 - Disable native lib tests in a browser.

--- a/lib/MessageDigest-webcrypto.js
+++ b/lib/MessageDigest-webcrypto.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const {crypto} = require('./platform');
+const {bufferToHex, crypto} = require('./platform');
 
 module.exports = class MessageDigest {
   /**
@@ -31,13 +31,7 @@ module.exports = class MessageDigest {
 
   async digest() {
     const data = new TextEncoder().encode(this._content);
-    const buffer = new Uint8Array(
-      await crypto.subtle.digest(this.algorithm, data));
-    // return digest in hex
-    let hex = '';
-    for(let i = 0; i < buffer.length; ++i) {
-      hex += buffer[i].toString(16).padStart(2, '0');
-    }
-    return hex;
+    const buffer = await crypto.subtle.digest(this.algorithm, data);
+    return bufferToHex(buffer);
   }
 };

--- a/lib/platform-browser.js
+++ b/lib/platform-browser.js
@@ -9,3 +9,18 @@ exports.setImmediate = setImmediate;
 
 // WebCrypto
 exports.crypto = globalThis.crypto;
+
+// precompute byte to hex table
+const byteToHex = [];
+for(let n = 0; n <= 0xff; ++n) {
+  byteToHex.push(n.toString(16).padStart(2, '0'));
+}
+
+exports.bufferToHex = function bufferToHex(buffer) {
+  let hex = '';
+  const bytes = new Uint8Array(buffer);
+  for(let i = 0; i < bytes.length; ++i) {
+    hex += byteToHex[bytes[i]];
+  }
+  return hex;
+};

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -8,3 +8,7 @@ exports.setImmediate = setImmediate;
 // WebCrypto
 const crypto = require('node:crypto');
 exports.crypto = crypto.webcrypto;
+
+exports.bufferToHex = function bufferToHex(buffer) {
+  return Buffer.from(buffer).toString('hex');
+};


### PR DESCRIPTION
- Improvement depends on number of digests performed.
- Browser:
  - Precompute a byte-to-hex table.
  - ~4-9% improvement overall using improved algorithm in Node.js.
  - Browsers should see similar speedup. Node.js normally will use the method below.
- Node.js:
  - Use native `Buffer.from(...).toString('hex')` conversion.
  - ~5-12% improvement overall.
  - The non-WebCrypto MessageDigest on Node.js is still faster.

Getting consistent benchmarks on a non-idle system for the async webcrypto code is difficult.  Numbers below can be +/-2%.

# bytes-to-hex

## Comparison
| Test                 |  'base' | 'precompute' | 'buffer' |
| :------------------- | ------: | -----------: | -------: |
| #manifest#block-1    | 4709.85 |        5.53% |    5.36% |
| #manifest#block-2    |  863.09 |        8.77% |   11.26% |
| #manifest#block-10   |  189.20 |        6.40% |    7.34% |
| #manifest#block-100  |   18.97 |        9.89% |   12.30% |
| #manifest#block-1000 |    1.97 |        4.21% |    5.90% |

> base ops/s and relative difference (higher is better)

## Environment
| Key             | Values                                   |
| --------------- | ---------------------------------------- |
| Label           | 'base', 'precompute', 'buffer'           |
| Arch            | x64                                      |
| CPU             | Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz |
| CPUs            | 8                                        |
| Platform        | linux                                    |
| Runtime         | Node.js                                  |
| Runtime Version | v16.19.1                                 |
| Comment         | 'bytes-to-hex'                           |