### PR TITLE
Optimize a N-Quads serialization call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - Improvement depends on number of digests performed.
   - Node.js using the improved browser algorithm can be ~4-9% faster overall.
   - Node.js native `Buffer` conversion can be ~5-12% faster overall.
+- Optimize a N-Quads serialization call.
 
 ### Fixed
 - Disable native lib tests in a browser.

--- a/lib/URDNA2015.js
+++ b/lib/URDNA2015.js
@@ -188,19 +188,15 @@ module.exports = class URDNA2015 {
 
       // 3.1.1) If any component in quad is an blank node, then serialize it
       // using a special identifier as follows:
-      const copy = {
-        subject: null, predicate: quad.predicate, object: null, graph: null
-      };
       // 3.1.2) If the blank node's existing blank node identifier matches
       // the reference blank node identifier then use the blank node
       // identifier _:a, otherwise, use the blank node identifier _:z.
-      copy.subject = this.modifyFirstDegreeComponent(
-        id, quad.subject, 'subject');
-      copy.object = this.modifyFirstDegreeComponent(
-        id, quad.object, 'object');
-      copy.graph = this.modifyFirstDegreeComponent(
-        id, quad.graph, 'graph');
-      nquads.push(NQuads.serializeQuad(copy));
+      nquads.push(NQuads.serializeQuadComponents(
+        this.modifyFirstDegreeComponent(id, quad.subject, 'subject'),
+        quad.predicate,
+        this.modifyFirstDegreeComponent(id, quad.object, 'object'),
+        this.modifyFirstDegreeComponent(id, quad.graph, 'graph')
+      ));
     }
 
     // 4) Sort nquads in lexicographical order.

--- a/lib/URDNA2015Sync.js
+++ b/lib/URDNA2015Sync.js
@@ -184,19 +184,15 @@ module.exports = class URDNA2015Sync {
 
       // 3.1.1) If any component in quad is an blank node, then serialize it
       // using a special identifier as follows:
-      const copy = {
-        subject: null, predicate: quad.predicate, object: null, graph: null
-      };
       // 3.1.2) If the blank node's existing blank node identifier matches
       // the reference blank node identifier then use the blank node
       // identifier _:a, otherwise, use the blank node identifier _:z.
-      copy.subject = this.modifyFirstDegreeComponent(
-        id, quad.subject, 'subject');
-      copy.object = this.modifyFirstDegreeComponent(
-        id, quad.object, 'object');
-      copy.graph = this.modifyFirstDegreeComponent(
-        id, quad.graph, 'graph');
-      nquads.push(NQuads.serializeQuad(copy));
+      nquads.push(NQuads.serializeQuadComponents(
+        this.modifyFirstDegreeComponent(id, quad.subject, 'subject'),
+        quad.predicate,
+        this.modifyFirstDegreeComponent(id, quad.object, 'object'),
+        this.modifyFirstDegreeComponent(id, quad.graph, 'graph')
+      ));
     }
 
     // 4) Sort nquads in lexicographical order.


### PR DESCRIPTION
Remove a temporary object and object property manipulation in favor of a direct function call.

I had difficulty getting benchmark results with any confidence.  This patch may not have much effect in practice with modern VMs, but does look like it will do less work.