### PR TITLE
Optimize N-Quads escape/unescape.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   - Node.js using the improved browser algorithm can be ~4-9% faster overall.
   - Node.js native `Buffer` conversion can be ~5-12% faster overall.
 - Optimize a N-Quads serialization call.
+- Optimize N-Quads escape/unescape:
+  - Run regex test before doing a replace call.
+  - Performance difference depends on data and how often escape/unescape would
+    need to be called. A benchmark test data showed ~3-5% overall improvement.
 
 ### Fixed
 - Disable native lib tests in a browser.

--- a/lib/NQuads.js
+++ b/lib/NQuads.js
@@ -363,6 +363,9 @@ const _escapeRegex = /["\\\n\r]/g;
  * Escape string to N-Quads literal
  */
 function _escape(s) {
+  if(!_escapeRegex.test(s)) {
+    return s;
+  }
   return s.replace(_escapeRegex, function(match) {
     switch(match) {
       case '"': return '\\"';
@@ -379,6 +382,9 @@ const _unescapeRegex =
  * Unescape N-Quads literal to string
  */
 function _unescape(s) {
+  if(!_unescapeRegex.test(s)) {
+    return s;
+  }
   return s.replace(_unescapeRegex, function(match, code, u, U) {
     if(code) {
       switch(code) {


### PR DESCRIPTION
- Run regex test before doing a replace call.
- Performance difference depends on data and how often escape/unescape would need to be called. A benchmark test data showed ~3-5% overall improvement.

The benchmark here shows improvement, but in the case where data is always being escaped, this patch would be slower.  We could add flags to control this, but for now making an assumption overall this will be an improvement.

# test-then-replace

## Comparison
| Test                 |   'base' | 'new' | 'new' |
| :------------------- | -------: | ----: | ----: |
| #manifest#block-1    | 11111.08 | 5.62% | 5.55% |
| #manifest#block-2    |  2719.06 | 3.64% | 5.17% |
| #manifest#block-10   |   604.62 | 4.28% | 4.07% |
| #manifest#block-100  |    59.56 | 0.96% | 3.15% |
| #manifest#block-1000 |     5.50 | 3.04% | 4.00% |

> base ops/s and relative difference (higher is better)

## Environment
| Key             | Values                                   |
| --------------- | ---------------------------------------- |
| Label           | 'base', 'new'                            |
| Arch            | x64                                      |
| CPU             | Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz |
| CPUs            | 8                                        |
| Platform        | linux                                    |
| Runtime         | Node.js                                  |
| Runtime Version | v16.19.1                                 |
| Comment         | 'test-then-replace'                      |
